### PR TITLE
Currently provider of the server should change the code for chat with someone (not only with himself) after each change of ip address. On programming phase it's not necessary.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ input { border: 1px solid green; }
     chat.appendChild(line);
   }
 
-  var socket = new WebSocket('ws://127.0.0.1/chat');
+  var socket = new WebSocket('ws://' + window.location.hostname + '/chat');
 
   socket.onopen = function() {
     writeLine('connected');


### PR DESCRIPTION
Connection address for WebSocket client has been changed from '127.0.0.1' (localhost) to 'window.location.hostname'. This allows the server work property with a non-local clients, right out of the box.
